### PR TITLE
Removed ingested hook, it was removing "generate_orc" from the RELS-EXT ...

### DIFF
--- a/islandora_book_batch.module
+++ b/islandora_book_batch.module
@@ -46,15 +46,6 @@ function islandora_book_batch_islandora_bookCModel_islandora_object_ingested($ob
 }
 
 /**
- * Implements hook_CMODEL_PID_islandora_object_ingested().
- */
-function islandora_book_batch_islandora_pageCModel_islandora_object_ingested($object) {
-  if ($object->relationships->get(ISLANDORA_RELS_EXT_URI, 'generate_ocr', '', TRUE)) {
-    $object->relationships->remove(ISLANDORA_RELS_EXT_URI, 'generate_ocr', '', TRUE);
-  }
-}
-
-/**
  * A batch operation to remove the flag.
  */
 function islandora_book_batch_remove_pdf_flag($object, &$context) {


### PR DESCRIPTION
...before it could be used by the deriviative code.
