### PR TITLE
7.x islandora-1533

### DIFF
--- a/includes/batch.form.inc
+++ b/includes/batch.form.inc
@@ -61,6 +61,17 @@ function islandora_book_batch_form($form, &$form_state, $object) {
         '#description' => t('Whether or not we should generate OCR for the pages of the book.'),
         '#default_value' => TRUE,
       );
+      $form['aggregate_ocr'] = array(
+        '#type' => 'checkbox',
+        '#title' => t('Aggregate OCR?'),
+        '#description' => t('Whether or not we should generate OCR for the books after ingesting all of the pages.'),
+        '#default_value' => FALSE,
+        '#states' => array(
+          'invisible' => array(
+            ':input[name="generate_ocr"]' => array('checked' => FALSE),
+          ),
+        ),
+      );
     }
   }
   $form['email_admin'] = array(

--- a/includes/islandora_book_batch.inc
+++ b/includes/islandora_book_batch.inc
@@ -407,6 +407,9 @@ class IslandoraBookBookBatchObject extends IslandoraFlatBatchObject {
     if (isset($this->preprocessorParameters['create_pdfs']) && $this->preprocessorParameters['create_pdfs']) {
       islandora_paged_content_set_pdf_flag($this);
     }
+    if (isset($this->preprocessorParameters['aggregate_ocr']) && $this->preprocessorParameters['aggregate_ocr']) {
+      islandora_paged_content_set_ocr_flag($this);
+    }
     if (isset($this->preprocessorParameters['page_progression']) && $this->preprocessorParameters['page_progression']) {
       islandora_paged_content_set_page_progression($this, $this->preprocessorParameters['page_progression']);
     }

--- a/islandora_book_batch.drush.inc
+++ b/islandora_book_batch.drush.inc
@@ -61,6 +61,10 @@ function islandora_book_batch_drush_command() {
         'description' => 'A flag to allow for conditional OCR generation.',
         'value' => 'optional',
       ),
+      'aggregate_ocr' => array(
+        'description' => 'A flag to cause OCR to be aggregated to books, if OCR is also being generated per-page.',
+        'value' => 'optional',
+      ),
       'email_admin' => array(
         'description' => 'A flag to notify the site admin when the book is ' .
         'fully ingested (depends on Rules being enabled).',
@@ -105,6 +109,7 @@ function drush_islandora_book_batch_preprocess() {
     'parent_relationship_uri' => drush_get_option('parent_relationship_uri', 'info:fedora/fedora-system:def/relations-external#'),
     'parent_relationship_pred' => drush_get_option('parent_relationship_pred', 'isMemberOfCollection'),
     'create_pdfs' => drush_get_option('create_pdfs', FALSE),
+    'aggregate_ocr' => drush_get_option('aggregate_ocr', FALSE),
     'email_admin' => drush_get_option('email_admin', FALSE),
     'wait_for_metadata' => drush_get_option('wait_for_metadata', FALSE),
     'directory_dedup' => drush_get_option('directory_dedup', FALSE),


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1533
# What does this Pull Request do?

Adds the option to aggregate OCR to the parent for both interface and drush batch ingests.
# How should this be tested?
- A Drush batch ingest should be attempted both with and without the new 'aggregate_ocr' flag set.
- A book should be ingested through the book batch UI with and without the aggregate OCR flag checked.
- Default behaviour should be checked to see if it matches previous default behaviour.
# Background context:

The purpose of ISLANDORA-1533 is to allow OCR datastreams to be aggregated and stored with the parent paged object so they can be indexed into Solr, and so that pages can be hidden from search results. This pull request adds the ability to aggregate that OCR at the time of batch ingest.
# Screenshots (if appropriate)
## Before Screenshot

![book batch before](https://cloud.githubusercontent.com/assets/3406327/10947381/042cb0f2-82fe-11e5-8c99-71d3b4430cf3.png)
## After Screenshot

![book batch after](https://cloud.githubusercontent.com/assets/3406327/10947388/0be542a0-82fe-11e5-8913-cf8991d88f82.png)
# Additional Information

This change depends on https://github.com/Islandora/islandora_paged_content/pull/108

**Tagging:** @Islandora/7-x-1-x-committers as well as @whikloj who is the component manager here.

---

QA Dan
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
