### PR TITLE
Islandora 1548

### DIFF
--- a/includes/islandora_book_batch.inc
+++ b/includes/islandora_book_batch.inc
@@ -228,7 +228,7 @@ EOXML;
           $datastream->setContentFromFile($meta->uri, FALSE);
         }
         // MARCXML, transform to MODS and set.
-        elseif ($s_xml->getName() == 'record') {
+        elseif (in_array($s_xml->getName(), array('record', 'collection'))) {
           $datastream->content = static::runXslTransform(array(
             'input' => $xml,
             'xsl' => $dir . '/transforms/MARC21slim2MODS3-4.xsl',


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1548
# What does this Pull Request do?

Makes islandora_book_batch respect MARCXML records with top-level elements of 'collection'.
# How should this be tested?

Make a book_batch zip with a MARCXML record that has a 'collection', not a 'record', as its top-level element.  When ingested, the MODS generated should be filled with information from the MARCXML record.
# Background context:

This is a bug that's been reported through a client.  The fix is similar in nature to https://github.com/Islandora/islandora_batch/pull/51
# Additional Notes:
- **Does this change require documentation to be updated?** No
- **Does this change add any new dependencies?** No
- **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No
- **Could this change impact execution of existing code?** No

**Tagging:** @Islandora/7-x-1-x-committers

---

Daniel Lamb
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
