### PR TITLE
Output the set ID when preprocessing is complete.

### DIFF
--- a/islandora_book_batch.drush.inc
+++ b/islandora_book_batch.drush.inc
@@ -84,6 +84,10 @@ function islandora_book_batch_drush_command() {
         'description' => 'A flag to indicate the page progression for the book. If not specified will default to LR.',
         'value' => 'optional',
       ),
+      'output_set_id' => array(
+        'description' => 'A flag to indicate whether to print the set ID of the preprocessed book.',
+        'value' => 'optional',
+      ),
     ),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
   );
@@ -134,6 +138,10 @@ function drush_islandora_book_batch_preprocess() {
 
   // Pass the preprocessor off to run.
   $preprocessed = islandora_batch_handle_preprocessor($preprocessor);
+
+  if (drush_get_option('output_set_id', FALSE)) {
+    drush_print($preprocessor->getSetId());
+  }
 }
 
 /**


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1618 
# What does this Pull Request do?

Allows the set ID of a preprocessed set to be outputted when preprocessing is complete.
# How should this be tested?

Preprocess a set of items with the `--output_set_id` flag set.
Note that the set ID of the preprocessed set is printed out.
# Background context:

Let the set ID of the newly preprocessed set be displayed and potentially used as input in other scripts when preprocessing completes.

Similar to what exists in scan batch: https://github.com/Islandora/islandora_batch/blob/7.x/islandora_batch.drush.inc#L157-L158.
# Additional Notes:
- **Does this change require documentation to be updated?** No.
- **Does this change add any new dependencies?** No.
- **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No.
- **Could this change impact execution of existing code?** No.

**Tagging:** @whikloj  
## Thanks!

Jordan Dukart
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
