### PR TITLE
add ocr/hocr ignore options

### DIFF
--- a/includes/batch.form.inc
+++ b/includes/batch.form.inc
@@ -57,14 +57,20 @@ function islandora_book_batch_form($form, &$form_state, $object) {
     if ($derive['ocr']) {
       $form['generate_ocr'] = array(
         '#type' => 'checkbox',
-        '#title' => t('Generate OCR?'),
-        '#description' => t('Whether or not we should generate OCR for the pages of the book.'),
+        '#title' => t('Generate OCR'),
+        '#description' => t('Generate OCR for the pages of each book.'),
+        '#default_value' => TRUE,
+      );
+      $form['generate_hocr'] = array(
+        '#type' => 'checkbox',
+        '#title' => t('Generate HOCR'),
+        '#description' => t('Generate HOCR for the pages of each book.'),
         '#default_value' => TRUE,
       );
       $form['aggregate_ocr'] = array(
         '#type' => 'checkbox',
-        '#title' => t('Aggregate OCR?'),
-        '#description' => t('Whether or not we should generate OCR for the books after ingesting all of the pages.'),
+        '#title' => t('Aggregate OCR'),
+        '#description' => t('Consolidate the page OCR and add it to the books after ingesting all of the pages.'),
         '#default_value' => FALSE,
         '#states' => array(
           'invisible' => array(

--- a/includes/islandora_book_batch.inc
+++ b/includes/islandora_book_batch.inc
@@ -475,11 +475,14 @@ class IslandoraBookPageBatchObject extends IslandoraFlatBatchObject {
     islandora_paged_content_set_relationship($rels_ext, FEDORA_RELS_EXT_URI, 'isMemberOf', $this->parentId);
     // Add content model relationship.
     $this->models = 'islandora:pageCModel';
-    if (isset($this->preprocessorParameters['generate_ocr']) || isset($this->preprocessorParameters['generate_hocr'])) {
+    // The existence of the generate_ocr and generate_hocr parameters are both
+    // dependent on the existence of the islandora_ocr module, so only one
+    // isset() is necessary.
+    if (isset($this->preprocessorParameters['generate_ocr'])) {
       module_load_include('inc', 'islandora_ocr', 'includes/derivatives');
       islandora_ocr_set_generating_rels_ext_statements($this,
-        isset($this->preprocessorParameters['generate_ocr']) ? $this->preprocessorParameters['generate_ocr'] : FALSE,
-        isset($this->preprocessorParameters['generate_hocr']) ? $this->preprocessorParameters['generate_hocr'] : FALSE);
+        isset($this->preprocessorParameters['generate_ocr']) ? (bool) $this->preprocessorParameters['generate_ocr'] : FALSE,
+        isset($this->preprocessorParameters['generate_hocr']) ? (bool) $this->preprocessorParameters['generate_hocr'] : FALSE);
     }
   }
 }

--- a/includes/islandora_book_batch.inc
+++ b/includes/islandora_book_batch.inc
@@ -475,9 +475,11 @@ class IslandoraBookPageBatchObject extends IslandoraFlatBatchObject {
     islandora_paged_content_set_relationship($rels_ext, FEDORA_RELS_EXT_URI, 'isMemberOf', $this->parentId);
     // Add content model relationship.
     $this->models = 'islandora:pageCModel';
-    if (isset($this->preprocessorParameters['generate_ocr'])) {
+    if (isset($this->preprocessorParameters['generate_ocr']) || isset($this->preprocessorParameters['generate_hocr'])) {
       module_load_include('inc', 'islandora_ocr', 'includes/derivatives');
-      islandora_ocr_set_generate_ocr_rels_ext_statement($this, $this->preprocessorParameters['generate_ocr']);
+      islandora_ocr_set_generating_rels_ext_statements($this,
+        isset($this->preprocessorParameters['generate_ocr']) ? $this->preprocessorParameters['generate_ocr'] : FALSE,
+        isset($this->preprocessorParameters['generate_hocr']) ? $this->preprocessorParameters['generate_hocr'] : FALSE);
     }
   }
 }

--- a/islandora_book_batch.drush.inc
+++ b/islandora_book_batch.drush.inc
@@ -57,6 +57,10 @@ function islandora_book_batch_drush_command() {
         'description' => 'A flag to allow for conditional OCR generation.',
         'value' => 'optional',
       ),
+      'do_not_generate_hocr' => array(
+        'description' => 'A flag to allow for conditional HOCR generation.',
+        'value' => 'optional',
+      ),
       'aggregate_ocr' => array(
         'description' => 'A flag to cause OCR to be aggregated to books, if OCR is also being generated per-page.',
         'value' => 'optional',
@@ -138,12 +142,8 @@ function drush_islandora_book_batch_preprocess() {
     $parameters['content_models'] = array('islandora:bookCModel');
   }
 
-  if ($do_not_generate = drush_get_option('do_not_generate_ocr', FALSE)) {
-    $parameters['generate_ocr'] = FALSE;
-  }
-  else {
-    $parameters['generate_ocr'] = TRUE;
-  }
+  $parameters['generate_ocr'] = !((bool) drush_get_option('do_not_generate_ocr', FALSE));
+  $parameters['generate_hocr'] = !((bool) drush_get_option('do_not_generate_hocr', FALSE));
 
   $preprocessor = new IslandoraBookBatch($connection, $parameters);
 

--- a/islandora_book_batch.drush.inc
+++ b/islandora_book_batch.drush.inc
@@ -142,8 +142,10 @@ function drush_islandora_book_batch_preprocess() {
     $parameters['content_models'] = array('islandora:bookCModel');
   }
 
-  $parameters['generate_ocr'] = !((bool) drush_get_option('do_not_generate_ocr', FALSE));
-  $parameters['generate_hocr'] = !((bool) drush_get_option('do_not_generate_hocr', FALSE));
+  if (module_exists('islandora_ocr')) {
+    $parameters['generate_ocr'] = !((bool) drush_get_option('do_not_generate_ocr', FALSE));
+    $parameters['generate_hocr'] = !((bool) drush_get_option('do_not_generate_hocr', FALSE));
+  }
 
   $preprocessor = new IslandoraBookBatch($connection, $parameters);
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2012

* Other Relevant Links: Hard-requirement on https://github.com/Islandora/islandora_ocr/pull/81

# What does this Pull Request do?
Adds the option to ignore OCR/HOCR derivative generation when batch ingesting books through the UI/Drush.
Also some language updates to clarify some odd things.

# What's new?
* Options in the book batch UI to opt out of OCR/HOCR derivative generation individually, not just one for both.
* A new flag, --do_not_generate_hocr, to opt out of HOCR derivative generation on Drush batches.
* The --do_not_generate_ocr flag now only opts out of OCR derivative generation.

# How should this be tested?
* Run the UI book batch ingest and test each of the OCR/HOCR opt-out options.
* Run the drush book batch ingest with the --do_not_generate_ocr and/or the --do_not_generate_hocr flags.
In all cases, OCR/HOCR should only be generated if it isn't opted out of.

# Additional Notes:
This has the potential to impact shell scripts that perform Drush scripting given the splitting of --do_not_generate_ocr into --do_not_generate_ocr and --do_not_generate_hocr. Shell scripts that currently rely on this flag would need to be updated to have flags split out.

# Interested parties
@jordandukart bein' the person on the thing
