### PR TITLE
ISLANDORA-2053: Update travis.yml to force PHP 5.3.3 to run under Ubuntu Precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,37 @@
 sudo: required
+dist: trusty
 language: php
+
+matrix:
+  include:
+   #5.3.3 Ubuntu Precise exceptions
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.5"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.6.2"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.7.0"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.8.1"
 php:
-  - 5.3.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
-branches:
-  only:
-    - /^7.x/
 env:
   - FEDORA_VERSION="3.5"
   - FEDORA_VERSION="3.6.2"
   - FEDORA_VERSION="3.7.0"
   - FEDORA_VERSION="3.8.1"
+
+branches:
+  only:
+    - /^7.x/
 before_install:
   - cd $HOME
   - git clone -b 7.x git://github.com/Islandora/islandora.git


### PR DESCRIPTION
**ISLANDORA-2053**: (https://jira.duraspace.org/browse/ISLANDORA-2053)
http://irclogs.islandora.ca/2017-09-05.html
https://github.com/travis-ci/travis-ci/issues/2963
https://github.com/Islandora/islandora/pull/683

As of September 2017, Travis-CI has removed support for PHP 5.3 (and 5.2) for their Ubuntu Trusty Images, forcing us, in order  to keep Drupal's compatibility matrix tested, to run Travis-CI test for 5.3 on Ubuntu Precise

# What does this Pull Request do?

This pull Fixes our failing Travis-CI tests: 
Should allow PHP 5.3.3 to run under Ubuntu Precise and Higher versions under Ubuntu Trusty.
Changes the way we define which PHP versions and Fedora ones run in Travis

# What's new?
We moved PHP 5.3.3 version and the corresponding Fedora versions into the matrix section of the Travis YAML file. 

# How should this be tested?
Travis-CI should pass and everything single PHP/FEDORA version combination should look good and very green. On Merge PLEASE SQUASH. (since these are a lot of pulls and I tend to make some typos, I could be pulling more than one commit). Thanks!

# Interested parties
@Islandora/7-x-1-x-committers @rosiel @whikloj @jonathangreen @jordandukart @adam-vessey @qadan 