### PR TITLE
Address ISLANDORA-2375; set child model dynamically

### DIFF
--- a/includes/islandora_book_batch.inc
+++ b/includes/islandora_book_batch.inc
@@ -479,7 +479,7 @@ class IslandoraBookPageBatchObject extends IslandoraFlatBatchObject {
     $paged_cmodels = islandora_paged_content_retrieve_applicable_cmodels();
     foreach ($this->preprocessorParameters['content_models'] as $parent_model) {
       if (isset($paged_cmodels[$parent_model]['children'])) {
-        $chid_models = array_merge($chid_models, array_keys($paged_cmodels[$parent_model]['children']));
+        $child_models = array_merge($child_models, array_keys($paged_cmodels[$parent_model]['children']));
       }
     }
     $child_models = array_unique($child_models);

--- a/includes/islandora_book_batch.inc
+++ b/includes/islandora_book_batch.inc
@@ -384,9 +384,20 @@ class IslandoraBookBookBatchObject extends IslandoraFlatBatchObject {
    * Function getChildren.
    */
   public function getChildren(IslandoraTuque $connection) {
+    // Get child content model based on parent.
+    if (!isset($this->preprocessorParameters['child_content_models'])) {
+      module_load_include('inc', 'islandora_paged_content', 'includes/utilities');
+      $child_models = array();
+      $paged_cmodels = islandora_paged_content_retrieve_applicable_cmodels();
+      foreach ($this->preprocessorParameters['content_models'] as $parent_model) {
+        if (isset($paged_cmodels[$parent_model]['children'])) {
+          $child_models = array_merge($child_models, array_keys($paged_cmodels[$parent_model]['children']));
+        }
+      }
+      $this->preprocessorParameters['child_content_models'] = array_unique($child_models);
+    }
     // Create page objects, return in an array.
     $children = array();
-
     foreach ($this->objectInfo as $sequence => $info) {
       if ($sequence != '.') {
         $children[] = new IslandoraBookPageBatchObject($connection, $this->id, $sequence, $info, $this->preprocessorParameters);
@@ -466,7 +477,7 @@ class IslandoraBookPageBatchObject extends IslandoraFlatBatchObject {
    */
   public function addRelationships() {
     module_load_include('inc', 'islandora_paged_content', 'includes/utilities');
-    // Add relationship to parent.
+    // Add parent relationships to child.
     $rels_ext = $this->relationships;
     islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isPageOf', $this->parentId);
     islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isSequenceNumber', (string) $this->sequenceNumber, TRUE);
@@ -475,16 +486,9 @@ class IslandoraBookPageBatchObject extends IslandoraFlatBatchObject {
     islandora_paged_content_set_relationship($rels_ext, FEDORA_RELS_EXT_URI, 'isMemberOf', $this->parentId);
 
     // Add content model relationship.
-    $child_models = array();
-    $paged_cmodels = islandora_paged_content_retrieve_applicable_cmodels();
-    foreach ($this->preprocessorParameters['content_models'] as $parent_model) {
-      if (isset($paged_cmodels[$parent_model]['children'])) {
-        $child_models = array_merge($child_models, array_keys($paged_cmodels[$parent_model]['children']));
-      }
-    }
-    $child_models = array_unique($child_models);
-    if (!empty($child_models)) {
-      $this->models = $child_models;
+    if (isset($this->preprocessorParameters['child_content_models']) &&
+      !empty($this->preprocessorParameters['child_content_models'])) {
+      $this->models = $this->preprocessorParameters['child_content_models'];
     }
     else {
       $this->models = 'islandora:pageCModel';

--- a/includes/islandora_book_batch.inc
+++ b/includes/islandora_book_batch.inc
@@ -475,16 +475,16 @@ class IslandoraBookPageBatchObject extends IslandoraFlatBatchObject {
     islandora_paged_content_set_relationship($rels_ext, FEDORA_RELS_EXT_URI, 'isMemberOf', $this->parentId);
 
     // Add content model relationship.
-    $chid_models = array();
+    $child_models = array();
     $paged_cmodels = islandora_paged_content_retrieve_applicable_cmodels();
     foreach ($this->preprocessorParameters['content_models'] as $parent_model) {
       if (isset($paged_cmodels[$parent_model]['children'])) {
         $chid_models = array_merge($chid_models, array_keys($paged_cmodels[$parent_model]['children']));
       }
     }
-    $chid_models = array_unique($chid_models);
-    if (!empty($chid_models)) {
-      $this->models = $chid_models;
+    $child_models = array_unique($child_models);
+    if (!empty($child_models)) {
+      $this->models = $child_models;
     }
     else {
       $this->models = 'islandora:pageCModel';

--- a/includes/islandora_book_batch.inc
+++ b/includes/islandora_book_batch.inc
@@ -466,15 +466,30 @@ class IslandoraBookPageBatchObject extends IslandoraFlatBatchObject {
    */
   public function addRelationships() {
     module_load_include('inc', 'islandora_paged_content', 'includes/utilities');
-    // Add relationship to collection.
+    // Add relationship to parent.
     $rels_ext = $this->relationships;
     islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isPageOf', $this->parentId);
     islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isSequenceNumber', (string) $this->sequenceNumber, TRUE);
     islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isPageNumber', (string) $this->sequenceNumber, TRUE);
     islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isSection', '1', TRUE);
     islandora_paged_content_set_relationship($rels_ext, FEDORA_RELS_EXT_URI, 'isMemberOf', $this->parentId);
+
     // Add content model relationship.
-    $this->models = 'islandora:pageCModel';
+    $chid_models = array();
+    $paged_cmodels = islandora_paged_content_retrieve_applicable_cmodels();
+    foreach ($this->preprocessorParameters['content_models'] as $parent_model) {
+      if (isset($paged_cmodels[$parent_model]['children'])) {
+        $chid_models = array_merge($chid_models, array_keys($paged_cmodels[$parent_model]['children']));
+      }
+    }
+    $chid_models = array_unique($chid_models);
+    if (!empty($chid_models)) {
+      $this->models = $chid_models;
+    }
+    else {
+      $this->models = 'islandora:pageCModel';
+    }
+
     // The existence of the generate_ocr and generate_hocr parameters are both
     // dependent on the existence of the islandora_ocr module, so only one
     // isset() is necessary.


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2375

# What does this Pull Request do?
Sets the child model based on parent model

# What's new?
Uses the paged content model registry to set child content model instead of hardcoding it to islandora:pageCModel.

# How should this be tested?
Construct a book batch and ingest using book batch module. Verify parent and child model match registry. It should default to islandora:bookCModel and islandora:pageCModel.

# Additional Notes:
* Does this change the interface, add a new feature, or otherwise change behaviours that would require updating documentation? No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# Interested parties
@adam-vessey as maintainer @Islandora/7-x-1-x-committers 
